### PR TITLE
✨ traffic::url can now get *and* set all components

### DIFF
--- a/include/traffic/url.hpp
+++ b/include/traffic/url.hpp
@@ -11,19 +11,28 @@ struct url : private offset {
   url (pointer, TSMBuffer, pointer) noexcept;
   url (pointer, TSMBuffer) noexcept;
 
-  std::string_view parameters () const noexcept;
-  std::string_view password () const noexcept;
-  std::string_view fragment () const noexcept;
-  std::string_view scheme () const noexcept;
-  std::string_view query () const noexcept;
-  std::string_view path () const noexcept;
-  std::string_view host () const noexcept;
-  std::string_view user () const noexcept;
+  [[nodiscard]] std::string_view parameters () const noexcept;
+  [[nodiscard]] std::string_view password () const noexcept;
+  [[nodiscard]] std::string_view fragment () const noexcept;
+  [[nodiscard]] std::string_view scheme () const noexcept;
+  [[nodiscard]] std::string_view query () const noexcept;
+  [[nodiscard]] std::string_view path () const noexcept;
+  [[nodiscard]] std::string_view host () const noexcept;
+  [[nodiscard]] std::string_view user () const noexcept;
+  [[nodiscard]] int port () const noexcept;
 
-  explicit operator std::string () const;
+  void parameters (std::string_view) noexcept;
+  void password (std::string_view) noexcept;
+  void fragment (std::string_view) noexcept;
+  void scheme (std::string_view) noexcept;
+  void query (std::string_view) noexcept;
+  void path (std::string_view) noexcept;
+  void host (std::string_view) noexcept;
+  void user (std::string_view) noexcept;
+  void port (int) noexcept;
 
-  std::size_t size () const noexcept;
-  int port () const noexcept;
+  [[nodiscard]] std::size_t size () const noexcept;
+  [[nodiscard]] bool empty () const noexcept;
 
   using offset::buffer;
   using offset::parent;

--- a/src/url.cxx
+++ b/src/url.cxx
@@ -6,11 +6,20 @@
 namespace {
 
 using extract_function_type = auto(*)(TSMBuffer, TSMLoc, int*) -> char const*;
+using insert_function_type = auto(*)(TSMBuffer, TSMLoc, char const*, int) -> TSReturnCode;
 
 std::string_view extract(extract_function_type fn, traffic::url const& url) {
   int length { 0 };
-  auto text = std::invoke(fn, url.buffer(), url.get(), std::addressof(length));
+  auto text = fn(url.buffer(), url.get(), std::addressof(length));
   return { text, static_cast<std::size_t>(length) };
+}
+
+void insert(insert_function_type fn, traffic::url const& url, char const* str,  std::size_t len) {
+  auto length = static_cast<int>(len);
+  auto result = fn(url.buffer(), url.get(), str, length);
+  if (result != TS_SUCCESS) {
+    TSDebug("netlify.traffic.internals", "Unable to set URL subproperty with value '%.*s'", length, str);
+  }
 }
 
 } /* nameless namespace */
@@ -33,19 +42,55 @@ std::string_view url::query () const noexcept { return ::extract(TSUrlHttpQueryG
 std::string_view url::path () const noexcept { return ::extract(TSUrlPathGet, *this); }
 std::string_view url::host () const noexcept { return ::extract(TSUrlHostGet, *this); }
 std::string_view url::user () const noexcept { return ::extract(TSUrlUserGet, *this); }
+int url::port () const noexcept { return TSUrlPortGet(this->buffer(), this->get()); }
 
-url::operator std::string () const {
-  int length { 0 };
-  auto text = TSUrlStringGet(this->buffer(), this->get(), std::addressof(length));
-  apex::scope_exit exit { [=] { TSfree(text); } };
-  return { text, static_cast<std::size_t>(length) };
+void url::parameters (std::string_view value) noexcept {
+  ::insert(TSUrlHttpParamsSet, *this, value.data(), value.size());
+}
+
+void url::password (std::string_view value) noexcept {
+  ::insert(TSUrlPasswordSet, *this, value.data(), value.size());
+}
+
+void url::fragment (std::string_view value) noexcept {
+  ::insert(TSUrlHttpFragmentSet, *this, value.data(), value.size());
+}
+
+void url::scheme (std::string_view value) noexcept {
+  ::insert(TSUrlSchemeSet, *this, value.data(), value.size());
+}
+
+void url::query (std::string_view value) noexcept {
+  ::insert(TSUrlHttpQuerySet, *this, value.data(), value.size());
+}
+
+void url::path (std::string_view value) noexcept {
+  ::insert(TSUrlPathSet, *this, value.data(), value.size());
+}
+
+void url::host (std::string_view value) noexcept {
+  ::insert(TSUrlHostSet, *this, value.data(), value.size());
+}
+
+void url::user (std::string_view value) noexcept {
+  ::insert(TSUrlUserSet, *this, value.data(), value.size());
+}
+
+void url::port (int value) noexcept {
+  auto result = TSUrlPortSet(this->buffer(), this->get(), value);
+  if (result != TS_SUCCESS) {
+    TSDebug("netlify.traffic.internals", "Could not set URL port to %d", value);
+  }
 }
 
 std::size_t url::size () const noexcept { return TSUrlLengthGet(this->buffer(), this->get()); }
-int url::port () const noexcept { return TSUrlPortGet(this->buffer(), this->get()); }
+bool url::empty () const noexcept { return this->size() == 0; }
 
 std::string to_string (url const& u) {
-  return static_cast<std::string>(u);
+  int length { 0 };
+  auto text = TSUrlStringGet(u.buffer(), u.get(), std::addressof(length));
+  apex::scope_exit exit { [=] { TSfree(text); } };
+  return { text, static_cast<std::size_t>(length) };
 }
 
 } /* namespace traffic */


### PR DESCRIPTION
✨ Add [[nodiscard]] attributes to traffic::url get functions
✨ Add .empty() to traffic::url
🔥 Remove explicit string cast to convert traffic::url to string.
  Use traffic::to_string instead
