### PR TITLE
♻ Refactor traffic::uuid to support parsing strings and converting to std::string

### DIFF
--- a/include/traffic/uuid.hpp
+++ b/include/traffic/uuid.hpp
@@ -1,6 +1,8 @@
 #ifndef TRAFFIC_UUID_HPP
 #define TRAFFIC_UUID_HPP
 
+#include <apex/core/optional.hpp>
+#include <apex/core/string.hpp>
 #include <traffic/memory.hpp>
 #include <ts/ts.h>
 
@@ -12,11 +14,21 @@ template <> struct default_delete<TSUuid> {
 };
 
 struct uuid : private unique_handle<TSUuid> {
+
+  static apex::optional<uuid> parse (std::string const&) noexcept;
+  static apex::optional<uuid> parse (apex::zstring_view) noexcept;
+  static apex::optional<uuid> parse (char const*) noexcept;
+
   using resource_type::resource_type;
+  using resource_type::operator bool;
   using resource_type::get;
+
+  char const* data () const noexcept;
+  size_t size () const noexcept; /* O(n) operation */
 };
 
-std::string_view to_string (uuid) noexcept;
+apex::zstring_view to_string_view (uuid) noexcept;
+std::string to_string (uuid);
 
 } /* namespace traffic */
 

--- a/src/uuid.cxx
+++ b/src/uuid.cxx
@@ -1,4 +1,5 @@
 #include <traffic/uuid.hpp>
+#include <cstring>
 
 namespace traffic {
 
@@ -6,8 +7,20 @@ void default_delete<TSUuid>::operator () (pointer ptr) const noexcept {
   TSUuidDestroy(ptr);
 }
 
-std::string_view to_string (uuid value) noexcept {
-  return TSUuidStringGet(value.get());
+apex::optional<uuid> uuid::parse (std::string const& str) noexcept { return uuid::parse(str.data()); }
+apex::optional<uuid> uuid::parse (apex::zstring_view str) noexcept { return uuid::parse(str.data()); }
+apex::optional<uuid> uuid::parse (char const* str) noexcept {
+  auto ptr = TSUuidCreate();
+  auto result = TSUuidStringParse(ptr, str);
+  if (result == TS_SUCCESS) { return uuid(ptr); }
+  TSUuidDestroy(ptr);
+  return std::nullopt;
 }
+
+char const* uuid::data () const noexcept { return TSUuidStringGet(this->get()); }
+size_t uuid::size () const noexcept { return strlen(this->data()); }
+
+apex::zstring_view to_string_view (uuid value) noexcept { return value.data(); }
+std::string to_string (uuid value) { return value.data(); }
 
 } /* namespace traffic */


### PR DESCRIPTION
Parsing is a pass/fail operation so we simply use an apex::optional<T>
for the operation
