### PR TITLE
✨ add traffic::borrowed_mutex(TSCont) constructor

### DIFF
--- a/include/traffic/mutex.hpp
+++ b/include/traffic/mutex.hpp
@@ -34,6 +34,8 @@ struct [[clang::capability("mutex")]] mutex : protected unique_handle<TSMutex> {
 struct [[clang::capability("mutex")]] borrowed_mutex : protected view_handle<TSMutex> {
   using native_handle_type = TSMutex;
 
+  borrowed_mutex (TSCont cont) noexcept;
+
   borrowed_mutex& operator = (borrowed_mutex const&) = delete;
   borrowed_mutex (borrowed_mutex const&) = delete;
 

--- a/src/mutex.cxx
+++ b/src/mutex.cxx
@@ -18,6 +18,10 @@ void mutex::lock () noexcept { TSMutexLock(this->get()); }
 
 mutex::native_handle_type mutex::native_handle () const noexcept { return this->get(); }
 
+borrowed_mutex::borrowed_mutex (TSCont cont) noexcept :
+  borrowed_mutex(TSContMutexGet(cont))
+{ }
+
 bool borrowed_mutex::try_lock () noexcept {
   return TSMutexLockTry(this->get()) == traffic::success;
 }


### PR DESCRIPTION
While the continuation type we have allows for it to be used "as a
lock", we haven't correctly wrapped the type in its entirety (and it
will be some time before we do, as we need to add wrapping callbacks
correctly first). However in the interim, we can build a borrowed_mutex
from a TSCont.
