### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
           lld-10
       - name: Select Download Build Type
         id: download
-        run: echo "::set-output name=type::$(echo ${{matrix.build-type}} | tr '[:upper:]' '[:lower:]')"
+        run: echo "type=$(echo ${{matrix.build-type}} | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
       - name: Download Dependencies
         run: >
           gh release download

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version: '3.x'
       - name: Get Pip Cache Directory
-        run: echo "::set-output name=dir::$(pip cache dir)"
+        run: echo "dir=$(pip cache dir)" >> "$GITHUB_OUTPUT"
         id: pip-cache
       - name: Cache Dependencies
         uses: actions/cache@v2


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter